### PR TITLE
Adjust gameplay duration and speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A simple browser game built with React where a flying squirrel glides through ho
 The page now bundles local copies of React, so no internet connection is required.
 2. Press **Spacebar** or tap to make the squirrel flap upward.
 3. Pass through the center of each hoop to score.
-4. If you miss a hoop or fail to clear enough hoops each minute, the game ends. Click **Restart** to play again.
+4. If you miss a hoop or fail to clear enough hoops every 30 seconds, the game ends. Click **Restart** to play again.
 
-The game now runs for five minutes with circles moving faster over time. You must pass through at least 20 hoops each minute to keep playing.
+The game now runs for two minutes with circles speeding up by 10% every 10 seconds. You must pass through at least 10 hoops every 30 seconds to keep playing.
 
 The game uses React for rendering and CSS transitions for smooth movement. A small oscillator sound is played on each flap. The layout is responsive, so you can play on desktop or mobile.

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const HOOP_INTERVAL = 2000; // ms
 const BASE_HOOP_SPEED = 2;
 const SQUIRREL_X = 100;
 const HOOP_SIZE = 80;
-const GAME_DURATION = 300; // 5 minutes
+const GAME_DURATION = 120; // 2 minutes
 const WIN_SCORE = 100;
 
 function randomY() {
@@ -115,13 +115,14 @@ function App() {
 
   useEffect(() => {
     if (timeLeft <= 0) setRunning(false);
-    const elapsedMinutes = Math.floor((GAME_DURATION - timeLeft) / 60);
-    if (elapsedMinutes > 0 && (GAME_DURATION - timeLeft) % 60 === 0) {
-      if (score < elapsedMinutes * 20) {
+    const elapsedPeriods = Math.floor((GAME_DURATION - timeLeft) / 30);
+    if (elapsedPeriods > 0 && (GAME_DURATION - timeLeft) % 30 === 0) {
+      if (score < elapsedPeriods * 10) {
         setRunning(false);
       }
     }
-    setHoopSpeed(BASE_HOOP_SPEED + (GAME_DURATION - timeLeft) / 120);
+    const speedMultiplier = Math.pow(1.1, Math.floor((GAME_DURATION - timeLeft) / 10));
+    setHoopSpeed(BASE_HOOP_SPEED * speedMultiplier);
   }, [timeLeft]);
 
 
@@ -139,6 +140,9 @@ function App() {
   return (
     React.createElement('div', { id: 'game' },
       React.createElement('div', { className: 'score' }, `Score: ${score} Missed: ${misses} Time: ${timeLeft}`),
+      React.createElement('div', { className: 'instructions' },
+        'Press Space or tap to flap. Pass at least 10 hoops every 30 seconds for 2 minutes.'
+      ),
       React.createElement('div', {
         className: `squirrel${success ? ' success' : ''}`,
         style: { transform: `translate(${SQUIRREL_X}px, ${squirrelY}px) scaleX(1)` }

--- a/style.css
+++ b/style.css
@@ -44,6 +44,14 @@ body {
   font-weight: bold;
 }
 
+.instructions {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  color: #333;
+  font-size: 18px;
+}
+
 .game-over {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
## Summary
- shorten game duration from 5 minutes to 2 minutes
- require 10 hoops every 30 seconds
- increase hoop speed by 10% every 10 seconds
- show on-screen instructions
- update README with new rules

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68542f4beb008323851253e757dbe00a